### PR TITLE
Post Soft Launch Design Chores

### DIFF
--- a/app/assets/stylesheets/incident_pages/_map.scss
+++ b/app/assets/stylesheets/incident_pages/_map.scss
@@ -35,7 +35,7 @@ hr {
         margin-left: 0;
     }
     & h4 {
-        margin-left: 13px;
+        /*margin-left: 13px;*/
         margin-top: 10px;
     }
     & input[type="checkbox"] + label, input[type="radio"] + label {
@@ -49,21 +49,35 @@ hr {
             padding: 10px;
     }
     & .simple_form {
-        max-height: 500px; /* fits viewport on standard laptop screen */
+        height: 90vh; /* temporary fix? works for modern browsers...need to test*/
         overflow-y: scroll;
         width: 95%;
         margin-left: 5%;
         & .columns {
             padding-left: 0;
-        }       
+            margin-bottom: 5px;
+        }    
+        & label {
+            font-size: 0.775rem;
+        }
         & input[type="text"], input[type="password"], input[type="date"], input[type="datetime"], input[type="datetime-local"], input[type="month"], input[type="week"], input[type="email"], input[type="number"], input[type="tel"], input[type="time"], input[type="url"], input[type="color"]{
             width: 100%;
-            height: 1.8rem;
+            height: 1.5rem;
             margin: 0;
+            font-size: .775rem;
+            padding: 0 2.5px 0 2.5px;
         }
-        & select {
+        & input[type="file"], input[type="checkbox"], input[type="radio"], select {
+            margin: 0 0 5px 0;
+        }
+        & select, option {
             width: 100%;
+            height: 1.5rem;
+            margin: 0;
+            font-size: .775rem;
+            padding: 0 2.5px 0 2.5px;
         }
+            
         & textarea {
             height: 100px;
         }
@@ -75,6 +89,18 @@ hr {
     }
 }
 
+// Google Maps Autocomplete
+        & .pac-container {
+            left: 0;
+            width: 26.5%!important;
+        }
+        & .pac-item {
+            height: 1.5rem;
+            margin: 0 0 5px 0;
+            font-size: .775rem;
+            word-wrap: break-word;
+            height: auto;
+        }
 
 .sideblock {
     & .columns {
@@ -102,7 +128,6 @@ table {
 .map-wrapper {
     width: 100%;
     height: 100%;
-    min-height:600px;
     background-color: $smoke;
 }
 
@@ -133,17 +158,28 @@ table {
   width: 60%;
   left: 215px;
   overflow-y: scroll;
-  & .close {
-    z-index: 3;
-    position: absolute;
-    right: 0.25rem;
-    top: 0.25rem;
-    background: inherit;
-    color: #333333;
-    font-size: 1.375rem;
-    opacity: 0.3;
-    padding: 0 6px 4px;
-  }
+    & .columns {
+        margin-bottom: 5px;
+        font-size: .775rem;
+    }
+    & select {
+        width: 100%;
+        height: 1.5rem;
+        margin: 0;
+        font-size: .775rem;
+        padding: 0 2.5px 0 2.5px;
+    }
+    & .close {
+        z-index: 3;
+        position: absolute;
+        right: 0.25rem;
+        top: 0.25rem;
+        background: inherit;
+        color: #333333;
+        font-size: 1.375rem;
+        opacity: 0.3;
+        padding: 0 6px 4px;
+    }
     & .button {
         margin-right: 5px;
     }
@@ -196,6 +232,10 @@ table {
     }
     .map-margin-fix, .form-margin-fix {
         margin-top: -23.6px;
+    }
+    & .pac-container {
+        left: 0;
+        width: 88.5%!important;
     }
 }
 

--- a/app/views/worker/incident/legacy_sites/form.html.erb
+++ b/app/views/worker/incident/legacy_sites/form.html.erb
@@ -12,7 +12,7 @@
     <span class='m-id hidden'><%= @legacy_event.id %></span>
     <span class='m-pin hidden'>init</span>
     <div class='map-wrapper'>
-      <div id="worker-map-canvas" class="form-margin-fix" style="width: 100%; min-height: 600px; height: 100%;"></div>
+      <div id="worker-map-canvas" class="form-margin-fix" style="width: 100%; min-height: 90vh; height: 90vh;"></div>
       <%= image_tag "map_legend.png", :class => "legend"  %>
     </div>
   </div>


### PR DESCRIPTION
- reduced infobox and simple form labels 
- text, inputs and margins. 
- adjusted Google Maps Autocomplete sizing, word wrap still WIP
- fixed sidebar / map height differential on different sized screens.
--> NOTE: new measurement unit "vh" used instead of pixels, rems, percentages. VH sizes containers based on viewport height instead of a definitive size or scalable percentage. It works on modern browsers however it will need thorough testing with older browsers.

RSPEC passed. Should be good to merge and I can build on top of it later.