### PR TITLE
Reduce batch size.

### DIFF
--- a/app/controllers/worker/incident/legacy_sites_controller.rb
+++ b/app/controllers/worker/incident/legacy_sites_controller.rb
@@ -152,7 +152,7 @@ module Worker
         Enumerator.new do |y|
           y << Legacy::LegacySite.csv_header.to_s
 
-          Legacy::LegacySite.find_in_batches({legacy_event_id: params[:id]}, 200) { |site| y << site.to_csv_row.to_s }
+          Legacy::LegacySite.find_in_batches({legacy_event_id: params[:id]}, 100) { |site| y << site.to_csv_row.to_s }
         end
       end
 


### PR DESCRIPTION
Try reducing the amount of work orders in each batch to see if it fixes the issue.

Assumes a memory problem which hasn't been confirmed.