### PR TITLE
Temporary CSV Bug Workaround

### DIFF
--- a/app/views/worker/incident/legacy_sites/map.html.erb
+++ b/app/views/worker/incident/legacy_sites/map.html.erb
@@ -30,7 +30,7 @@
       <h4>Map Filters</h4>
           <div id="map-filters"></div>
         <h4>Download</h4>
-        <a href="#" class="button tiny" id="download-csv-btn" style="margin-left: 13px;">CSV</a>
+        <a href="#" class="button tiny" id="download-csv-btn" style="margin-left: 13px;">CSV</a> Not working? <a href="https://crisiscleanup.zendesk.com/hc/en-us/requests/new" class="button tiny" id="request-csv-btn" target="_blank" style="margin-left: 13px;">Request a CSV</a> <span data-tooltip aria-haspopup="true" class="has-tip tip-bottom" title="We are tracking down a bug that prevents CSV files with more than 5,000 rows from downloading everything. In the meantime, you may request a complete CSV by submitting a request."><i class="fa fa-question"></i></span>
         <p><em>Note: CSV does not include Damage Assessments (DAs). To convert a DA to a work order, edit the DA on the map and change the "Primary Help Needed" to something like "Flood."</em></p>
     </div>
     <div class="hide" id="form-view">


### PR DESCRIPTION
Because there is a bug that prevents the CSV from working consistently
for events bigger than 5,000 sites, this update adds a button to the map
for the user to manually request a complete CSV.